### PR TITLE
Upload actions artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,3 +55,9 @@ jobs:
         run: npm run dist -- --x64
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Binaries-${{ runner.os }}
+          path: dist/EKC-*


### PR DESCRIPTION
pros:
- verifiable builds (know that the actions build and the stuff in releases - which can be edited - are exactly identical) (building on my own computer has a chance of not producing the exact same file)
- bleeding edge builds

cons:
- hi zedboy